### PR TITLE
fix bloken link in footer

### DIFF
--- a/src/_footer.html
+++ b/src/_footer.html
@@ -4,7 +4,7 @@
       <div class="column">
         <h4 class="title is-6 has-text-grey-light"> About </h4>
         <a href="/use">Use </a> <br/>
-        <a href="/learn"> Learn </a> <br/>
+        <a href="/learn/intro.html"> Learn </a> <br/>
         <a href="/learn/faq.html"> FAQ  </a>  <br/>
       </div>
       <div class="column">


### PR DESCRIPTION
the link to the /learn subpage in the footer was giving a 404. Changed it to point at /learn/intro.html