### PR TITLE
css:  setting max height for image previews

### DIFF
--- a/src/blog/index.html
+++ b/src/blog/index.html
@@ -39,18 +39,10 @@ Blog : Stencila
 
 {% block styles %}
 {{ super() }}
-<!-- <style type="text/css">
-    .container {
-      max-width: 50em;
-    }
-    .post {
-      margin-bottom: 4em;
-      border: 1px solid #eee;
-      padding: 1em;
-    }
-    .post .image {
-      max-height: 200px;
+ <style type="text/css">
+.post .image {
+      max-height: 300px;
       overflow: hidden;
     }
-  </style> -->
+  </style> 
 {% endblock %}


### PR DESCRIPTION
This is a mediocre attempt to address a problem with the layout which occurs if one of the blog post images is quite high - see below
![image](https://user-images.githubusercontent.com/2358535/54006589-ce2c9580-41c2-11e9-812d-068ef83ee10b.png)

The changes in PR result in:
![image](https://user-images.githubusercontent.com/2358535/54006600-e4d2ec80-41c2-11e9-9125-e44283f38a6c.png)
