### PR TITLE
Fix: broken link to Stencila Hub

### DIFF
--- a/src/contribute/index.html
+++ b/src/contribute/index.html
@@ -41,7 +41,7 @@ Contribute to Stencila
                     </header>
                     <p>
                         If you want to help make Stencila available online, to support efficient sharing and
-                        collaboration, have a look at <a href="(https://github.com/stencila/hub">Stencila Hub</a>. Working on this project
+                        collaboration, have a look at <a href="https://github.com/stencila/hub">Stencila Hub</a>. Working on this project
                          will be particularly interesting for those who are into 
                         <a href="https://github.com/stencila/nixster">Nix</a>, 
                         <a href="https://github.com/stencila/dockter">Docker</a> 


### PR DESCRIPTION
Just wandering around and spotted the extra bracket hence broken link - Emmy @ eLife