### PR TITLE
docs(Update Website): Update copy and remove outdated documentation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -138,7 +138,7 @@ Links to `/contribute` page
 ##### Section `Discuss`
 
 Invitation to join discussions (mention topics) and information how to do it:
-- Gitter
+- Zulip
 - Stencila forum
 - Twitter
 - GitHub discussions in pull requests and issues

--- a/src/_footer.html
+++ b/src/_footer.html
@@ -3,7 +3,7 @@
         <div class="columns footer-links is-centered">
             <div class="column is-2">
                 <h4 class="title"> Tools </h4>
-                <a href="/use">Use </a> <br />
+                <!-- <a href="/use">Use </a> <br /> -->
                 <a href="/learn/intro.html"> Learn </a> <br />
                 <a href="/learn/faq.html"> FAQ </a> <br />
             </div>
@@ -14,7 +14,7 @@
                 <a href="/community/resources.html"> Resources </a> <br />
                 <a href="/blog"> Blog </a> <br />
             </div>
-            <div class="column is-2">
+            <div class="column is-k2">
                 <h4 class="title"> About </h4>
                 <a href="/about/team.html">Team</a> <br />
                 <a href="/about/advisory-board.html">Advisors</a> <br />
@@ -24,7 +24,7 @@
                 <h4 class="title"> Contact </h4>
                 <a href="mailto:hello@stenci.la">Email </a> <br />
                 <a href="https://twitter.com/stencila"> Twitter </a> <br />
-                <a href="https://gitter.im/stencila/stencila"> Gitter Chat </a> <br />
+                <a href="https://stencila.zulipchat.com/#narrow/stream/202396-community"> Zulip Chat </a> <br />
                 <a href="https://community.stenci.la/"> Community Forum </a> <br />
             </div>
         </div>

--- a/src/_footer.html
+++ b/src/_footer.html
@@ -14,7 +14,7 @@
                 <a href="/community/resources.html"> Resources </a> <br />
                 <a href="/blog"> Blog </a> <br />
             </div>
-            <div class="column is-k2">
+            <div class="column is-2">
                 <h4 class="title"> About </h4>
                 <a href="/about/team.html">Team</a> <br />
                 <a href="/about/advisory-board.html">Advisors</a> <br />

--- a/src/_header.html
+++ b/src/_header.html
@@ -21,7 +21,7 @@
             </div>
             <div class="navbar-menu">
                 <div class="navbar-start flex-grow-contents flex-end">
-                    <a class="navbar-item" href="/use">Use</a>
+                    <!-- <a class="navbar-item" href="/use">Use</a> -->
                     <a class="navbar-item" href="/learn/intro.html">Learn</a>
                     <a class="navbar-item" href="/contribute">Contribute</a>
                     <a class="navbar-item" href="/community">Community</a>

--- a/src/community/index.html
+++ b/src/community/index.html
@@ -40,11 +40,10 @@ Community : Stencila
                                 There are a number of <a href="/contribute/">ways you can contribute to Stencila</a>.
                                 We welcome and encourage <b>all</b> contributions. There is a lot you can do and through contributing
                                 to Stencila you can gain more experience and learn new skills.
-                                You can help out a lot by being <a href="beta-testing.html">Stencila Beta Tester.</a>
+                                You can help out a lot by being a <a href="beta-testing.html">Stencila Beta Tester.</a>
 
                                 <br /> <br />
-                                We are doing our best to make it easy for contributors to work with Stencila. If you have any suggestions
-                                how to improve their experience and, in particular, if you have any ideas on supporting the new contributors,
+                                We are doing our best to make it easy for contributors to work with Stencila. If you have any suggestions on improving the experience and, in particular, if you have any ideas on supporting new contributors,
                                 please <a mailto="community@stenci.la">get in touch</a>.
                             </p>
                             <hr class="is-small">
@@ -76,15 +75,15 @@ Community : Stencila
                                 <br />
                             </p>
                             <p>
-                                Join us also on <a href="https://gitter.im/stencila/stencila">Stencila Gitter chat</a>
+                                Join us also on <a href="https://stencila.zulipchat.com/#narrow/stream/202396-community">Stencila Zulip chat</a>.
                                 This chat channel is open to anyone who wants to or already
                                 uses Stencila, would like to develop Stencila or is already a contributor. Come and say hello!
                                 <br />
                                 <br />
                             </p>
                             <p>
-                                You can <a href="https://twitter.com/stencila">find us on Twitter</a> too or
-                                simply talk to us via <a mailto="community@stenci.la">email</a>..
+                                You can <a href="https://twitter.com/stencila">find us on Twitter</a>, too, or
+                                simply talk to us via <a mailto="community@stenci.la">email</a>...
                             </p>
                             <p>
                                 <br />
@@ -104,7 +103,7 @@ Community : Stencila
                         <div class="content">
                             <p>
                                 We are working on Stencila Hub to enable easy sharing of Stencila documents, including interactive
-                                articles and sheets. The Hub will allow researchers collaborate with their colleagues without the need
+                                articles and sheets. The Hub will allow researchers to collaborate with their colleagues without the need
                                 to abandon their preferred tool for data analysis and reporting. Stay tuned for the updates!
                             </p>
                             <hr class="is-small">
@@ -127,7 +126,7 @@ Community : Stencila
                             <p>
                                 We are committed to growing and maintaining a diverse
                                 and inclusive community. Everyone involved at any level with Stencila is required to obey
-                                our <a href="/community/code-of-conduct.html">Code of conduct</a>. We aim to ensure that Stencila community
+                                our <a href="/community/code-of-conduct.html">Code of conduct</a>. We aim to ensure that the Stencila community
                                 operates in a friendly and supportive environment.
                             </p>
                             <hr class="is-small">

--- a/src/contribute/index.html
+++ b/src/contribute/index.html
@@ -41,14 +41,14 @@ Contribute to Stencila
                     </header>
                     <p>
                         If you want to help make Stencila available online, to support efficient sharing and
-                        collaboration, have a look at <a href="https://github.com/stencila/hub">Stencila Hub</a>. Working on this project
-                         will be particularly interesting for those who are into 
-                        <a href="https://github.com/stencila/nixster">Nix</a>, 
-                        <a href="https://github.com/stencila/dockter">Docker</a> 
+                        collaboration, have a look at <a href="https://github.com/stencila/hub">Stencila Hub</a>. Work on this project
+                         will be particularly interesting for those who are into
+                        <a href="https://github.com/stencila/nixster">Nix</a>,
+                        <a href="https://github.com/stencila/dockter">Docker</a>
                         and Kubernetes.
                     </p>
                     <p>
-                        If you care about structured documents, interoperability of formats, data and are interested in schemas, have a look at 
+                        If you care about structured documents, interoperability of formats, data and are interested in schemas, have a look at
                         <a href="https://github.com/stencila/schema">Stencila Schema</a>.
                     </p>
                     <p>
@@ -57,7 +57,7 @@ Contribute to Stencila
                     </p>
                     <p>
                         If you would like to improve functionality of using Python from within Stencila,
-                        check the <a href="https://github.com/stencila/py">Stencila for Python</a>.
+                        check out <a href="https://github.com/stencila/py">Stencila for Python</a>.
                         And if you are an R developer, have a look at <a href="https://github.com/stencila/r">Stencila for R </a>.
                         Likewise the <a href="https://github.com/stencila/node">Stencila for Node.js</a> package for Javascript developers.
                     </p>
@@ -96,14 +96,14 @@ Contribute to Stencila
                         You will be taken to the the GitHub repository containing the website pages. If you don't know what it means, don't worry, just follow these steps:
                         <ol>
                             <li> Log into your GitHub account. If you don't have one, you will be given an option to create one.</li>
-                            <li> If you never edited the website, you will see a note <em>You need to fork this repository to propose changes.</em> </li>
+                            <li> If this is your first time editing the website, you will see a note <em>You need to fork this repository to propose changes.</em> </li>
                             <li> Click the green button <em>Fork this repository to propose changes</em></li>
                             <li>In the editor, simply make the changes you think should be there. Then, in the text box at the bottom (under
                                 <em>Commit changes</em>), put in a short note on what you did and click the button <em>Submit changes</em>.</li>
                         </ol>
                         <p>
                             We also welcome and very much need help documenting the source code. Please send us pull requests or simply
-                            <a href="mailto:hello@stenci.la"></a> get in touch if you'd like to improve source code documentation.
+                            <a href="mailto:hello@stenci.la">get in touch</a> if you'd like to improve source code documentation.
                         </p>
                         <hr class="is-small">
                 </div>
@@ -123,7 +123,7 @@ Contribute to Stencila
                     <p>
                         If you develop code for data manipulation (in Python, R, and other languages), you may be interested in
                         making your data manipulation code available through domain-specific libraries.
-                        Alternatively, you can help out with expanding the 
+                        Alternatively, you can help out with expanding the
                         <a href="https://github.com/stencila/libcore/blob/master/CONTRIBUTING.md">Stencila Core Library</a> which
                         comes with the basic Stencila installation and is implemented in JavaScript.
                     </p>

--- a/src/index.html
+++ b/src/index.html
@@ -7,14 +7,14 @@
     <div class="container">
         <div class="columns">
             <div class="column">
-                {{ heading(true, "An open source office suite for reproducible research.", small = "What is Stencila?") }}
+                {{ heading(true, "An open source platform for reproducible research.", small = "What is Stencila?") }}
 
                 <div class="content">
                     <p>The calls for research to be transparent and reproducible have never been louder. But today's tools for reproducible research can be intimidating - especially if you're not a coder.</p>
-                    <p><strong>Stencila</strong> makes reproducible research more accessible with intuitive word processor and spreadsheet interfaces that you and your colleagues are already used to.</p>
+                    <p><strong>Stencila</strong> makes reproducible research more accessible by preserving code and metadata throughout the authoring and publication process, in the word processor interfaces you and your colleagues are already used to.</p>
 
                     <p><strong><span class="icon"><i class="fa fa-flask"></i></span>
-                        Stencila</strong> is an open source project under active development. 
+                        Stencila</strong> is an open source project under active development.
                         We <span class="icon has-text-danger"><i class="fa fa-heart"></i></span> your <a href="/community/beta-testing.html">feedback</a> but please be patient
                         with bugs and instabilities!</p>
                 </div>
@@ -50,10 +50,41 @@
     <div class="container">
         <header class="heading has-text-centered">
             <span class="small">What makes it different?</span>
-            <h2 class="title has-line is-2 has-text-primary">Stencila comes with a bunch of <br>features that make it both flexible and powerful.</h2>
+            <h2 class="title has-line is-2 has-text-primary">Stencila comes with features that make it <br>both flexible and powerful.</h2>
         </header>
         <div class="card-grid-container">
             <div class="columns">
+                <div class="column is-one-third is-offset-2">
+                    <div class="card card--grid">
+                        <div class="card-image">
+                            <figure class="image is-4by3">
+                                <img src="img/icons/dockerfile-increment.svg">
+                            </figure>
+                        </div>
+                        <div class="card-content content">
+                            <p class="title is-4">Reproducibility from authoring through to publishing</p>
+                            <p>Stencila projects maintain reproducibility through the use of schemas, which preserve code and metadata across formats. We are working with authors and publishers on formats which extend existing publishing standards—allowing publications to embed code and making the publication process faster.</p>
+                            <hr class="is-small">
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third">
+                    <div class="card card--grid">
+                        <div class="card-image">
+                            <figure class="image is-4by3">
+                                <img src="img/icons/stencil-multi-doc.svg">
+                            </figure>
+                        </div>
+                        <div class="card-content content">
+                            <p class="title is-4">Interoperability with existing tools and workflows</p>
+                            <p>Stencila is developed not to replace existing tools, but to complement them. We work with communities of existing open source tools to improve interoperability. Stencila also supports file formats
+                                commonly used by researchers for reproducibility such as Jupyter Notebooks, RMarkdown and more.</p>
+                            <hr class="is-small">
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- <div class="columns">
                 <div class="column is-one-third">
                     <div class="card card--grid">
                         <div class="card-image">
@@ -99,39 +130,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="columns">
-                <div class="column is-one-third is-offset-2">
-                    <div class="card card--grid">
-                        <div class="card-image">
-                            <figure class="image is-4by3">
-                                <img src="img/icons/stencil-multi-doc.svg">
-                            </figure>
-                        </div>
-                        <div class="card-content content">
-                            <p class="title is-4">Interoperability with existing tools and workflows</p>
-                            <p>Stencila is developed not to replace existing tools, but to complement them. We are working with the communities of existing open source tools to improve interoperability. Stencila also aims to support file formats
-                                commonly used by researchers for reproducibility such as Jupyter Notebooks, RMarkdown and more.</p>
-                            <hr class="is-small">
-                        </div>
-                    </div>
-                </div>
-                <div class="column is-one-third">
-                    <div class="card card--grid">
-                        <div class="card-image">
-                            <figure class="image is-4by3">
-                                <img src="img/icons/dockerfile-increment.svg">
-                            </figure>
-                        </div>
-                        <div class="card-content content">
-                            <p class="title is-4">Reproducibility from authoring through to publishing</p>
-                            <p>Stencila projects are self-contained archives of documents and assets. We are working with authors and publishers on formats which extend existing publishing standards - allowing your publications to embed code and
-                                making the publication process faster.</p>
-                            <hr class="is-small">
-                        </div>
-                    </div>
-                </div>
-            </div>
+            </div> -->
         </div>
     </div>
 </section>
@@ -206,52 +205,5 @@
 
     </div>
 </section>
-
-<!-- <section id="funders" class="section">
-    <div class="container">
-        <h1 class="title is-3 is-gray has-text-centered">Funders</h1>
-        <figure class="is-flex is-horizontal-center">
-            <img src="/img/sloan.png">
-        </figure>
-    </div>
-</section>
-
-<section id="partners" class="section">
-    <div class="container">
-        <h1 class="title is-3 is-gray has-text-centered">Partners</h1>
-        <div class="columns is-multiline is-centered">
-            <div class="column is-narrow">
-                <a href="https://codeforscience.org">
-                    <img src="/img/css.png">
-                </a>
-            </div>
-            <div class="column is-narrow">
-                <a href="http://coko.foundation">
-                    <img src="/img/coko.jpg">
-                </a>
-            </div>
-            <div class="column is-narrow">
-                <a href="https://datproject.org">
-                    <img src="/img/dat.png">
-                </a>
-            </div>
-            <div class="column is-narrow">
-                <a href="https://elifesciences.org/">
-                    <img src="/img/elife.png">
-                </a>
-            </div>
-            <div class="column is-narrow">
-                <a href="http://substance.io">
-                    <img src="/img/substance.svg">
-                </a>
-            </div>
-            <div class="column is-narrow">
-                <a href="https://opensciencemooc.eu/">
-                    <img src="/img/open-science-mooc-logo.png">
-                </a>
-            </div>
-        </div>
-    </div>
-</section> -->
 
 {% endblock %}

--- a/src/index.html
+++ b/src/index.html
@@ -10,8 +10,9 @@
                 {{ heading(true, "An open source platform for reproducible research.", small = "What is Stencila?") }}
 
                 <div class="content">
-                    <p>The calls for research to be transparent and reproducible have never been louder. But today's tools for reproducible research can be intimidating - especially if you're not a coder.</p>
-                    <p><strong>Stencila</strong> makes reproducible research more accessible by preserving code and metadata throughout the authoring and publication process, in the word processor interfaces you and your colleagues are already used to.</p>
+                    <p>The calls for research to be transparent and reproducible have never been louder. But today's tools for reproducible research can be intimidating, and disparate workflows and technical literacy levels can make it difficult to collaborate.</p>
+                    <p><strong>Stencila</strong> lets researchers create reproducible papers in their favorite tools and environment, whether it's Jupyter Notebook and RMarkdown, or Word and Excel.
+                    </p>
 
                     <p><strong><span class="icon"><i class="fa fa-flask"></i></span>
                         Stencila</strong> is an open source project under active development.
@@ -54,7 +55,7 @@
         </header>
         <div class="card-grid-container">
             <div class="columns">
-                <div class="column is-one-third is-offset-2">
+                <div class="column is-one-third">
                     <div class="card card--grid">
                         <div class="card-image">
                             <figure class="image is-4by3">
@@ -63,7 +64,7 @@
                         </div>
                         <div class="card-content content">
                             <p class="title is-4">Reproducibility from authoring through to publishing</p>
-                            <p>Stencila projects maintain reproducibility through the use of schemas, which preserve code and metadata across formats. We are working with authors and publishers on formats which extend existing publishing standards—allowing publications to embed code and making the publication process faster.</p>
+                            <p>Stencila projects maintain reproducibility through the use of schemas, allowing you to preserve code, data, and metadata across formats. We are working with authors and publishers on formats which extend existing publishing standards—allowing publications to embed code and making the publication process faster.</p>
                             <hr class="is-small">
                         </div>
                     </div>
@@ -79,6 +80,20 @@
                             <p class="title is-4">Interoperability with existing tools and workflows</p>
                             <p>Stencila is developed not to replace existing tools, but to complement them. We work with communities of existing open source tools to improve interoperability. Stencila also supports file formats
                                 commonly used by researchers for reproducibility such as Jupyter Notebooks, RMarkdown and more.</p>
+                            <hr class="is-small">
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-third">
+                    <div class="card card--grid">
+                        <div class="card-image">
+                            <figure class="image is-4by3">
+                                <img src="img/icons/doctype-stencila.svg">
+                            </figure>
+                        </div>
+                        <div class="card-content content">
+                            <p class="title is-4">Automatic generation of beautiful, semantic, and living papers</p>
+                            <p>Instantaneously take your manuscript from a Jupyter Notebook, Rmd, or Word file to a readable, semantic and easy-to-share web pre-print.</p>
                             <hr class="is-small">
                         </div>
                     </div>

--- a/src/learn/_toc.html
+++ b/src/learn/_toc.html
@@ -4,9 +4,9 @@
     </p>
     <ul class="menu-list">
         <li><a class="is-active" href="/learn/intro.html">Introduction</a></li>
-        <li><a href="/use/install.html">Installation</a></li>
-        <li><a href="/learn/quick-start.html">Quick start</a></li>
-        <li><a href="/learn/troubleshooting.html">Troubleshooting</a></li>
+        <!-- <li><a href="/use/install.html">Installation</a></!--> -->
+        <!-- <li><a href="/learn/quick-start.html">Quick start</a></li> -->
+        <!-- <li><a href="/learn/troubleshooting.html">Troubleshooting</a></li> -->
         <li><a href="/learn/faq.html">FAQ</a></li>
     </ul>
     <!-- <p class="menu-label">
@@ -19,7 +19,7 @@
     <!-- <li><a href="/learn/computation/engine.html">Engine</a></li> -->
     <!-- <li><a href="/learn/computation/functions.html">Functions</a></li> -->
     <!-- </ul> -->
-    <p class="menu-label">
+    <!-- <p class="menu-label">
         Languages
     </p>
     <ul class="menu-list">
@@ -28,7 +28,7 @@
         <li><a href="/learn/languages/python.html">Python</a></li>
         <li><a href="/learn/languages/r.html">R</a></li>
         <li><a href="/learn/languages/sql.html">SQL</a></li>
-    </ul>
+    </ul> -->
 
     <p class="menu-label">
         Integrations

--- a/src/learn/faq.md
+++ b/src/learn/faq.md
@@ -5,12 +5,9 @@ smalltitle: Learn
 ---
 **I already use RMarkdown/JupyterNotebook. How can Stencila be useful for me?**<br/>
 
-Stencila allows you collaborate with colleagues who use other tools than RMarkdown and Jupyter Notebook,
-without you having to give up your favourite tool. [Stencila Coverters](http://stenci.la/learn/integrations/converters.html) make it possible to open documents in
-various formats (`R Markdown - Rmd`, `Jupyter Notebook - ipynb` and so on) in Stencila. The conversion is lossless for all interactive parts (such as code cells). Soon the Converters
-will also support conversion back to the original document. You can open the file in your tool of choice and see the changes your collaborator made.
- Stencila's interface provides editing environment similar to that of Word and Excel making it a low-entry barrier
- for collaborators unfamiliar with RMarkdown or Jupyter Notebook.
+Stencila allows you collaborate with colleagues who use tools other than RMarkdown and Jupyter Notebook,
+without you having to give up your favourite tool. [Stencila Encoda](http://stenci.la/learn/integrations/converters.html) makes it possible to open documents in
+various formats (`RMarkdown - Rmd`, `Jupyter Notebook - ipynb` and so on) in Stencila. The conversion is lossless for all interactive parts (such as code cells), and support conversion back to the original document. You can open the file in your tool of choice and see the changes your collaborator made.
 
  Stencila keeps track of the dependencies between the code cells supporting reactive programming. This means that when you change a particular value,
  other bits of code which depend on it, will get automatically updated. Note, that this feature can be disabled and you will be able to re-run code manually.
@@ -25,44 +22,10 @@ can easily collaborate on the same document using their preferred programming la
 **I don't write any code for my research. Is Stencila for me?** <br/>
 
 Yes, definitely Stencila is for you! Stencila allows you to write your papers just like
-you would do it in a popular text editor (MS Word or similar) but you can save it directly in a format
-commonly used by publishers JATS [Journal Article Tag Suite](https://en.wikipedia.org/wiki/Journal_Article_Tag_Suite)
+you would in a word processor (MS Word or similar) but you can save it directly in a format
+commonly used by publishers (JATS, [Journal Article Tag Suite](https://en.wikipedia.org/wiki/Journal_Article_Tag_Suite))
 giving you more control over the formatting of your manuscript.
 
-Soon [Stencila Converters](http://stenci.la/learn/integrations/converters.html) will allow you saving your document
-in formats compatible with other popular reproducible research tools
+[Stencila Encoda](http://stenci.la/learn/integrations/converters.html) allows you to save your document
+in formats compatible with popular reproducible research tools
 (such as Jupyter Notebook) creating more opportunities for collaboration.
-
-<hr />
-
-**What are Stencila Sheets?**<br/>
-
-Stencila Sheets provide a way towards working within an environment similar to spreadsheet software but supporting
-reproducible approach by linking sheet directly to the article allowing for capturing the analysis steps.
-
-Stencila will tie together the data in the spreadsheet, the methods you used to process the data and the researchers
-publication.
-
-![Example of Stencila Sheet](img/stencila-mini-spreadsheet.png)
-
-Stencila Sheets will make it possible for extending the spreadsheet functionality by registering functions written in other
-programming languages. Using simple Stencila API researchers can wrap up functions written in R, Python and other
-languages, register them and thus make them available through the Stencila Sheet interface.
-
-
-<hr />
-
-**I would like to try out Stencila but don't want to (or can't) install the whole suite on my machine. What can I do?**<br/>
-
-You can use [Stencila Hub](https://github.com/stencila/hub). The Hub hosts interactive Stencila documents with
-different execution contexts enabling collaboration and previewing Stencila Sheets and Articles. If you would like to access Stencila Hub,
-please [contact us](mailto:hello@stenci.la).
-
-
-<hr />
-
-**I am trying to use R/Python/SQL with Stencila Desktop but I am getting this error message `No peers able to provide: R/Python/SQL Context`** <br/>
-
-Error message `No peers able to provide....` means that there is no active execution context for the language you are trying to use. In this particular case, if
-you want to use `R`, `Python` or `SQL` within Stencila, you need to make sure you enabled the relevant execution context.
-See the [installation instructions](../use/install.html#use-other-programming-languages) for details.

--- a/src/learn/integrations/converters.md
+++ b/src/learn/integrations/converters.md
@@ -11,7 +11,7 @@ Encoda provides a collection of codecs for converting between, and composing tog
 
 ## Install
 
-The easiest way to use Encoda is to install the [`stencila` command line tool](https://github.com/stencila/stencila). Encoda powers `stencila convert`, and other commands, in that CLI. However, the version of Encoda in `stencila`, can lag behind the version in this repo. So if you want the latest functionality, install Encoda as a Node.js package:
+The easiest way to use Encoda is to install the [`stencila` command line tool](https://github.com/stencila/stencila). Encoda powers `stencila convert`, and other commands, in that CLI. However, the version of Encoda in `stencila`, can lag behind the version in [this repo](https://github.com/stencila/encoda). So if you want the latest functionality, install Encoda as a Node.js package:
 
 ```bash
 npm install @stencila/encoda --global
@@ -60,44 +60,44 @@ encoda convert paragraph.md - --to yaml
 
 ## Formats
 
-| Format                      | Codec         | Approach | Status | Issues                  | Coverage             |
-| --------------------------- | ------------- | -------- | ------ | ----------------------- | -------------------- |
+| Format                      | Codec         | Approach | Status     |
+| --------------------------- | ------------- | -------- | -----------|
 | **Text**                    |
-| Plain text                  | [txt]         | None     | β      | [⚠][txt-issues]         | ![][txt-cov]         |
-| Markdown                    | [md]          | Extens   | α      | [⚠][md-issues]          | ![][md-cov]          |
-| LaTex                       | [latex]       | -        | α      | [⚠][latex-issues]       | ![][latex-cov]       |
-| Microsoft Word              | [docx]        | rPNG     | α      | [⚠][docx-issues]        | ![][docx-cov]        |
-| Google Docs                 | [gdoc]        | rPNG     | α      | [⚠][gdoc-issues]        | ![][gdoc-cov]        |
-| Open Document Text          | [odt]         | rPNG     | α      | [⚠][odt-issues]         | ![][odt-cov]         |
-| HTML                        | [html]        | Extens   | α      | [⚠][html-issues]        | ![][html-cov]        |
-| JATS XML                    | [jats]        | Extens   | α      | [⚠][jats-issues]        | ![][jats-cov]        |
-| JATS XML (Pandoc-based)     | [jats-pandoc] | Extens   | α      | [⚠][jats-pandoc-issues] | ![][jats-pandoc-cov] |
-| Portable Document Format    | [pdf]         | rPNG     | α      | [⚠][pdf-issues]         | ![][pdf-cov]         |
+| Plain text                  | txt         | None     | β          |
+| Markdown                    | md          | Extens   | α          |
+| LaTex                       | latex       | -        | α          |
+| Microsoft Word              | docx        | rPNG     | α          |
+| Google Docs                 | gdoc        | rPNG     | α          |
+| Open Document Text          | odt         | rPNG     | α          |
+| HTML                        | html        | Extens   | α          |
+| JATS XML                    | jats        | Extens   | α          |
+| JATS XML (Pandoc-based)     | jats-pandoc | Extens   | α          |
+| Portable Document Format    | pdf         | rPNG     | α          |
 | **Notebooks**               |
-| Jupyter                     | [ipynb]       | Native   | α      | [⚠][ipynb-issues]       | ![][ipynb-cov]       |
-| RMarkdown                   | [xmd]         | Native   | α      | [⚠][xmd-issues]         | ![][xmd-cov]         |
+| Jupyter                     | ipynb       | Native   | α          |
+| RMarkdown                   | xmd         | Native   | α          |
 | **Presentations**           |
-| Microsoft Powerpoint        | [pptx]        | rPNG     | ✗      | [⚠][pptx-issues]        |
-| Demo Magic                  | [dmagic]      | Native   | β      | [⚠][dmagic-issues]      | ![][dmagic-cov]      |
+| Microsoft Powerpoint        | pptx        | rPNG     | ✗          |
+| Demo Magic                  | dmagic      | Native   | β          |
 | **Spreadsheets**            |
-| Microsoft Excel             | [xlsx]        | Formula  | β      | [⚠][xlsx-issues]        | ![][xlsx-cov]        |
-| Google Sheets               | [gsheet]      | Formula  | ✗      | [⚠][gsheet-issues]      |
-| Open Document Spreadsheet   | [ods]         | Formula  | β      | [⚠][ods-issues]         | ![][ods-cov]         |
+| Microsoft Excel             | xlsx        | Formula  | β          |
+| Google Sheets               | gsheet      | Formula  | ✗          |
+| Open Document Spreadsheet   | ods         | Formula  | β          |
 | **Tabular data**            |
-| CSV                         | [csv]         | None     | β      | [⚠][csv-issues]         | ![][csv-cov]         |
-| CSVY                        | [csvy]        | None     | ✗      | [⚠][csvy-issues]        |
-| Tabular Data Package        | [tdp]         | None     | β      | [⚠][tdp-issues]         | ![][tdp-cov]         |
+| CSV                         | csv         | None     | β          |
+| CSVY                        | csvy        | None     | ✗          |
+| Tabular Data Package        | tdp         | None     | β          |
 | **Collections**             |
-| Document Archive            | [dar]         | Extens   | ω      | [⚠][dar-issues]         | ![][dar-cov]         |
-| Filesystem Directory        | [dir]         | Extens   | ω      | [⚠][dir-issues]         | ![][dir-cov]         |
+| Document Archive            | dar         | Extens   | ω          |
+| Filesystem Directory        | dir         | Extens   | ω          |
 | **Data interchange, other** |
-| JSON                        | [json]        | Native   | ✔      | [⚠][json-issues]        | ![][json-cov]        |
-| JSON5                       | [json5]       | Native   | ✔      | [⚠][json5-issues]       | ![][json5-cov]       |
-| YAML                        | [yaml]        | Native   | ✔      | [⚠][yaml-issues]        | ![][yaml-cov]        |
-| Pandoc                      | [pandoc]      | Native   | β      | [⚠][pandoc-issues]      | ![][pandoc-cov]      |
-| Reproducible PNG            | [rpng]        | Native   | β      | [⚠][rpng-issues]        | ![][rpng-cov]        |
+| JSON                        | json        | Native   | ✔          |
+| JSON5                       | json5       | Native   | ✔          |
+| YAML                        | yaml        | Native   | ✔          |
+| Pandoc                      | pandoc      | Native   | β          |
+| Reproducible PNG            | rpng        | Native   | β          |
 | **Transport**               |
-| HTTP                        | [http]        |          | ✔      | [⚠][http-issues]        | ![][http-cov]        |
+| HTTP                        | http        |          | ✔          |
 
 **Key**
 

--- a/src/learn/integrations/converters.md
+++ b/src/learn/integrations/converters.md
@@ -1,145 +1,131 @@
 ---
 extends: learn/_page.html
-title: Stencila Converters
+title: Stencila Encoda
 ---
 
-![Stencila Converters](/learn/img/convert.png){style="display: inline; width: 12%; margin: 0 auto; padding-right: 1em; padding-bottom: 1em; float: left;" }
+![Stencila Encoda](/learn/img/convert.png){style="display: inline; width: 12%; margin: 0 auto; padding-right: 1em; padding-bottom: 1em; float: left;" }
 
-Stencila Converters allow you to convert between a range of formats commonly used for among researchers (and not only). The conversion of interactive source code sections of the document is lossless - you can still run the code after the conversion. This means that you can seamlessly collaborate with colleagues who prefer other than you interfaces, without yourself having to give up your tool of choice. Stencila Converters are using the awesome power of [pandoc](https://pandoc.org/) so if you are already a
-pandoc user, you should find the Converters easy to use.
+> "A codec is a device or computer program for encoding or decoding a digital data stream or signal. Codec is a portmanteau of coder-decoder. - [Wikipedia](https://en.wikipedia.org/wiki/Codec)
 
+Encoda provides a collection of codecs for converting between, and composing together, documents in various formats. The aim is not to achieve perfect lossless conversion between alternative document formats; there are already several tools for that. Instead the focus of Encoda is to use existing tools to encode and compose semantic documents in alternative formats.
 
-## Install{style="clear: left;"}
+## Install
 
-The easiest way to install the Converters is through installing [Stencila Command Line (CLI)](https://github.com/stencila/cli/releases) tool.
-The installation requires two steps:
-1. Download and unpack the binary file with the [CLI for your operating system](https://github.com/stencila/cli/releases).
-2. Copy the binary file to the relevant location in your operating system so that you can easily access the tool in the command line:
-  * on Windows: <br/>
-       1) create a folder in `C:\Program Files\` called `stencila`, <br/> 
-       2) copy the `stencila.exe` (which will be in the unpacked folder you just downloaded) file into it;  <br/> 
-       3) then open Windows Command Line and add the folder to the `PATH` variable : `setx path "%path%;C:\Program Files\stencila"`; <br/> 
- > Note that the above instructions will work for Windows 7 and above. If you are using a Windows machine with an older version of the 
- > operating system, please use this command in the command line: `set PATH=%PATH%;C:\Program Files\stencila`
- <br/> 
-  * on Linux, copy the `stencila` binary file to `/usr/local/bin/`;
-  * on Mac OS X, copy the `stencila` file to the ` /usr/local/bin/` folder.
+The easiest way to use Encoda is to install the [`stencila` command line tool](https://github.com/stencila/stencila). Encoda powers `stencila convert`, and other commands, in that CLI. However, the version of Encoda in `stencila`, can lag behind the version in this repo. So if you want the latest functionality, install Encoda as a Node.js package:
+
+```bash
+npm install @stencila/encoda --global
+```
 
 ## Use
 
-The basic use of the Converter is fairly simple. Open the terminal and type `stencila convert path-to-input-file path-to-output-file`, replacing
-`path-to-input-file` and `path-to-output-file` with actual paths. So for example:
+Encoda is intended to be used primarily as a library for other applications. However, it comes with a simple command line script which allows you to use the `convert` function directly e.g.
 
 ```bash
-stencila convert Stencila/examples/hello-world/hello-world/hello-world.md Stencila/examples/hello-world/hello-world.docx
+encoda convert notebook.ipynb notebook.docx
 ```
 
-You should see the following output message:
+Encoda will determine the input and output formats based on the file extensions. You can override these using the `--from` and `--to` options. e.g.
 
 ```bash
-✓  Success converting "Stencila/examples/hello-world/hello-world/hello-world.md" to "Stencila/examples/hello-world/hello-world.docx"
+encoda convert notebook.ipynb notebook.xml --to jats
 ```
 
-You can override the file format both from and to which the Converter is meant to convert. In order to do that, use the `--from` and `--to` options.
-In the example below the output file format will actually be `comma separated values`, even thought the output file name has a different extension (`txt`).
+You can decode an entire directory into a `Collection`. Encoda will traverse the directory, including subdirectories, decoding each file matching your glob pattern. You can then encode the `Collection` using the `dir` codec into a tree of HTML files e.g.
 
 ```bash
-stencila convert hospital.xlsx --to csv hospital.txt
+encoda convert myproject myproject-published --to dir --pattern '**/*.{rmd, csv}'
 ```
 
-If you don't specify the output for the Converter, it will display on the screen (standard output) the input file converted to the intermittent internal Stencila JSON format.
+You can also read content from the first argument. In that case, you'll need to specifying the `--from` format e.g.
 
 ```bash
-stencila convert hospital.xls
+encoda convert "{type: 'Paragraph', content: ['Hello world!']}" --from json5 paragraph.md
 ```
 
-```json
-{
-  "type": "Document",
-  "front": {
-    "name": {
-      "type": "String",
-      "data": "patient"
-    }
-  },
-  "body": [
-    {
-      "type": "Table",
-      "rows": [
-        [
-          [],
-          [
-            {
-              "type": "String",
-              "data": "Day 1"
-            }
-          ],
-```
-
-To get more help on using the Converter type `stencila convert -h`.
-
-### Convert to PDF
-
-Conversion to PDF will require `pdflatex` (because this is how [pandoc works](https://pandoc.org/MANUAL.html#creating-a-pdf)). Check the [installation details here](https://www.latex-project.org/get/).
-
-### Convert spreadsheets
-
-Stencila Converters support spreadsheet conversion.
+You can send output to the console by using `-` as the second argument and specifying the `--to` format e.g.
 
 ```bash
-stencila convert hospital.xlsx hospital.md
+encoda convert paragraph.md - --to yaml
 ```
 
-Should result in:
+| Option         | Description                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `--from`       | The format of the input content e.g. `--from md`                                          |
+| `--to`         | The format for the output content e.g. `--to html`                                        |
+| `--theme`      | The theme for the output (only applies to HTML, PDF and RPNG output) e.g. `--theme eLife` |
+| `--standalone` | Generate a standalone document, not a fragment (default `true`)                           |
+| `--bundle`     | Bundle all assets (e.g images, CSS and JS) into the document (default `false`)            |
+| `--debug`      | Print debugging information                                                               |
 
-```bash
-✓  Success converting "hospital.xlsx" to "hospital.md"
-```
+## Formats
 
-Note that conversion from `xlsx` format to `md` retains some metadata from the original spreadsheet:
+| Format                      | Codec         | Approach | Status | Issues                  | Coverage             |
+| --------------------------- | ------------- | -------- | ------ | ----------------------- | -------------------- |
+| **Text**                    |
+| Plain text                  | [txt]         | None     | β      | [⚠][txt-issues]         | ![][txt-cov]         |
+| Markdown                    | [md]          | Extens   | α      | [⚠][md-issues]          | ![][md-cov]          |
+| LaTex                       | [latex]       | -        | α      | [⚠][latex-issues]       | ![][latex-cov]       |
+| Microsoft Word              | [docx]        | rPNG     | α      | [⚠][docx-issues]        | ![][docx-cov]        |
+| Google Docs                 | [gdoc]        | rPNG     | α      | [⚠][gdoc-issues]        | ![][gdoc-cov]        |
+| Open Document Text          | [odt]         | rPNG     | α      | [⚠][odt-issues]         | ![][odt-cov]         |
+| HTML                        | [html]        | Extens   | α      | [⚠][html-issues]        | ![][html-cov]        |
+| JATS XML                    | [jats]        | Extens   | α      | [⚠][jats-issues]        | ![][jats-cov]        |
+| JATS XML (Pandoc-based)     | [jats-pandoc] | Extens   | α      | [⚠][jats-pandoc-issues] | ![][jats-pandoc-cov] |
+| Portable Document Format    | [pdf]         | rPNG     | α      | [⚠][pdf-issues]         | ![][pdf-cov]         |
+| **Notebooks**               |
+| Jupyter                     | [ipynb]       | Native   | α      | [⚠][ipynb-issues]       | ![][ipynb-cov]       |
+| RMarkdown                   | [xmd]         | Native   | α      | [⚠][xmd-issues]         | ![][xmd-cov]         |
+| **Presentations**           |
+| Microsoft Powerpoint        | [pptx]        | rPNG     | ✗      | [⚠][pptx-issues]        |
+| Demo Magic                  | [dmagic]      | Native   | β      | [⚠][dmagic-issues]      | ![][dmagic-cov]      |
+| **Spreadsheets**            |
+| Microsoft Excel             | [xlsx]        | Formula  | β      | [⚠][xlsx-issues]        | ![][xlsx-cov]        |
+| Google Sheets               | [gsheet]      | Formula  | ✗      | [⚠][gsheet-issues]      |
+| Open Document Spreadsheet   | [ods]         | Formula  | β      | [⚠][ods-issues]         | ![][ods-cov]         |
+| **Tabular data**            |
+| CSV                         | [csv]         | None     | β      | [⚠][csv-issues]         | ![][csv-cov]         |
+| CSVY                        | [csvy]        | None     | ✗      | [⚠][csvy-issues]        |
+| Tabular Data Package        | [tdp]         | None     | β      | [⚠][tdp-issues]         | ![][tdp-cov]         |
+| **Collections**             |
+| Document Archive            | [dar]         | Extens   | ω      | [⚠][dar-issues]         | ![][dar-cov]         |
+| Filesystem Directory        | [dir]         | Extens   | ω      | [⚠][dir-issues]         | ![][dir-cov]         |
+| **Data interchange, other** |
+| JSON                        | [json]        | Native   | ✔      | [⚠][json-issues]        | ![][json-cov]        |
+| JSON5                       | [json5]       | Native   | ✔      | [⚠][json5-issues]       | ![][json5-cov]       |
+| YAML                        | [yaml]        | Native   | ✔      | [⚠][yaml-issues]        | ![][yaml-cov]        |
+| Pandoc                      | [pandoc]      | Native   | β      | [⚠][pandoc-issues]      | ![][pandoc-cov]      |
+| Reproducible PNG            | [rpng]        | Native   | β      | [⚠][rpng-issues]        | ![][rpng-cov]        |
+| **Transport**               |
+| HTTP                        | [http]        |          | ✔      | [⚠][http-issues]        | ![][http-cov]        |
 
-![](/learn/img/convert-xlsx-screen.png)
+**Key**
 
-![](/learn/img/convert-xlsx-md.png)
+<details>
+  <summary><b id="format-approach">Approach</b>...</summary>
+  How executable nodes (e.g. `CodeChunk` and `CodeExpr` nodes) are represented
 
+- Native: the format natively supports executable nodes
+- Extens.: executable nodes are supported via extensions to the format
+- rPNG: executable nodes are supported via reproducible PNG images
+- Formula: executable `CodeExpr` nodes are represented using formulae
 
-### Convert projects
+</details>
 
-You can convert a whole folder into a supported by Stencila `DAR` project which will contain all your articles and spreadsheets ready to work with in Stencila.
-You need to specify the output format to have the `dar` extension:
+<details>
+  <summary><b id="format-status">Status</b>...</summary>
 
-```bash
-stencila convert path-to-folder path-to-project.dar
-```  
+- ✗: Not yet implemented
+- ω: Work in progress
+- α: Alpha, initial implementation
+- β: Beta, ready for user testing
+- ✔: Ready for production use
 
-Or you can do it using `--to` flag:
+</details>
 
-```bash
-stencila convert path-to-folder --to dar path-to-project
-```
+<details>
+  <summary><b id="format-issues">Issues</b>...</summary>
+  Link to open issues and PRs for the format (please check there before submitting a new issue 🙏)
+</details>
 
-Note that if you use `--to` flag and you don't spefify the `dar` extension in the output project name, the Converter will still complete the conversion.
-
-
-## Supported formats
-Stencila Converters recognize the file extensions and use the relevant converters. Below is the list of currently recognized file extensions:
-
-| Format                        |             Extension              |
-|:------------------------------|:----------------------------------:|
-| Delimiter Separated Values    |            `csv`, `tsv`            |
-| HTML                          |               `html`               |
-| JavaScript Object Notation    |               `json`               |
-| Journal Aricle Tag Suite      |               `jats`               |
-| Jupyter Notebook              |              `ipnyb`               |
-| Latex                         |               `tex`                |
-| Markdown                      |                `md`                |
-| Microsoft Excel               |               `xlsx`               |
-| Microsoft Word                |               `docx`               |
-| Open Document Spreadsheet     |               `ods`                |
-| Open Document Text            |               `odt`                |
-| Portable Document Format      |               `pdf`                |
-| RMarkdown                     |               `Rmd`                |
-| XMarkdown\*                   |               `Xmd`                |
-| Reproducible Document Archive | `sheet.xml`, `sheetml`, `jats.xml` |
-|                               |                                    |
-\* _In XMarkdown you can use any code blocks, e.g. `py`, `js` and so on._
+If you'd like to see a converter for your favorite format, look at the [listed issues](https://github.com/stencila/encoda/issues) and comment under the relevant one. If there is no issue regarding the converter you need, [create one](https://github.com/stencila/encoda/issues/new).

--- a/src/learn/intro.md
+++ b/src/learn/intro.md
@@ -34,7 +34,7 @@ The execution contexts determine the inputs and outputs of cells which enables a
 
 ![Stencila Encoda](img/convert.png){style="display: inline; width: 18%; margin: 0 auto; padding-right: 1em; float: left;" }
 
-Stencila includes a set of encoders/decoders which allow you to convert between a range of formats commonly used among researchers. Encoda support lossless conversion of interactive source code sections and (most of the time) formatting.{style="display: block;"}
+Stencila includes a set of encoders/decoders which allow you to convert between a range of formats commonly used among researchers. Encoda supports lossless conversion of interactive source code sections and (most of the time) formatting.{style="display: block;"}
 
 You can convert to and from formats used by:
 * Excel (*xlsx*, *csv*, *tsv*),
@@ -46,5 +46,5 @@ You can convert to and from formats used by:
 * publishing applications (*JATS*, *xml*),
 * and more...
 
-Encoda bridges formats commonly used across the workflow lifecycle, e.g.from Jupyter Notebook to RMarkdown to Word to JATS. It makes the collaboration more
+Encoda bridges formats commonly used across the workflow lifecycle, e.g. from Jupyter Notebook to RMarkdown to Word to JATS. It makes the collaboration more
 seamless and less painful.

--- a/src/learn/intro.md
+++ b/src/learn/intro.md
@@ -28,26 +28,13 @@ be used for practically any programming language as the execution contexts can b
 for R, Python, JavaScript, SQL and Mini (Stencila's own simple language).
 
 The execution contexts determine the inputs and outputs of cells which enables automatic conversion of data between languages. In other words, you can
- combine of multiple languages in one document.
+ combine multiple languages in one document.
 
+## Encoda
 
-## Sheets{style="clear: right;"}
+![Stencila Encoda](img/convert.png){style="display: inline; width: 18%; margin: 0 auto; padding-right: 1em; float: left;" }
 
-![Stencila Sheets](img/UI.png){style="display: inline; width: 18%; margin: 0 auto; padding-right: 1em; padding-bottom: 3em; float: left;" }
-
-Stencila comes with its own simple interface, Stencila Sheet, which can be used similarly to a typical spreadsheet application. We are working on plugins
-for dominant spreadsheet applications which will add capabilities for working with:
-* code in open-source languages,
-* shared, custom functions
-* shared, custom types (for data validation).
-
-In other words, Stencila Sheets (and in the future, the plugins) allow for execution of R, Python, SQL (and more languages) code via special “code-snippet” functions e.g. `r`, `py`, `sql`. This feature will help researchers working in spreadsheet make their work more robust, easier to test and collaborate on. {style="clear: right;"}
-
-## Converter
-
-![Stencila Converter](img/convert.png){style="display: inline; width: 18%; margin: 0 auto; padding-right: 1em; float: left;" }
-
-Stencila includes a set of import/export converters which allow you to convert between a range of formats commonly used for among researchers (and not only). Converters support lossless conversion of interactive source code sections and (most of the time) formatting.{style="display: block;"}
+Stencila includes a set of encoders/decoders which allow you to convert between a range of formats commonly used among researchers. Encoda support lossless conversion of interactive source code sections and (most of the time) formatting.{style="display: block;"}
 
 You can convert to and from formats used by:
 * Excel (*xlsx*, *csv*, *tsv*),
@@ -59,5 +46,5 @@ You can convert to and from formats used by:
 * publishing applications (*JATS*, *xml*),
 * and more...
 
-Converter bridges formats commonly used across the workflow lifecycle, e.g.from Jupyter Notebook to RMarkdown to Word to JATS. It makes the collaboration more
+Encoda bridges formats commonly used across the workflow lifecycle, e.g.from Jupyter Notebook to RMarkdown to Word to JATS. It makes the collaboration more
 seamless and less painful.

--- a/src/learn/quick-start.md
+++ b/src/learn/quick-start.md
@@ -5,7 +5,7 @@ smalltitle: Learn
 ---
 
 This page will guide you through your first steps with Stencila using a simple example. We will show you how to use Stencila to analyse and visualise data
-using `R` programming language (based on the [Data Carpentry R for Ecology module](https://datacarpentry.org/R-ecology-lesson/i)). Using other programming languages is analogous.
+using `R` programming language (based on the [Data Carpentry R for Ecology module](https://datacarpentry.org/R-ecology-lesson/)). Using other programming languages is analogous.
 
 1. Launch Stencila Desktop on your machine (if you are one of our Stencila Hub testers, log into your account).
 2. If you are using Stencila Desktop, make sure that you enabled R execution context on your machine. If you are using Stencila Hub, you don't need to do anything.

--- a/src/learn/troubleshooting.md
+++ b/src/learn/troubleshooting.md
@@ -83,7 +83,7 @@ If that doesn't help, it may be that what happened is  the execution context you
 * for Python or Jupyter Python context, open a terminal and type `python -m stencila`.
 
 
-# Stencila Converters
+# Stencila Encoda
 
 ### Converting files into a `dar` project results in an error  `Cannot read property 'length' of undefined`
 Most likely one of the files in the folder you are trying to convert is a `csv` file and our converter may be tripping over some

--- a/src/use/install.md
+++ b/src/use/install.md
@@ -26,10 +26,11 @@ Download the `.dmg` file for the latest [Stencila Desktop release]( https://gith
 
 ### Linux
 
-Or, use one of our Docker images which bundle these language packages (plus many other packages that our useful in data-driven research) in one reproducible computing environment:
+Or, use one of our Docker images which bundle these language packages (plus many other packages that are useful in data-driven research) in one reproducible computing environment:
 
-- [Stencila Docker images](#stencila-docker-images)
-Download the AppImage\* file for the latest [Stencila Desktop release]( https://github.com/stencila/desktop/releases). Then double click on it and click *yes* to "Make executable and run". Or, to install from command line, navigate to the folder where the AppImage file is located and then:
+- [Use other programming languages](#use-other-programming-languages)
+  - [Stencila Docker images](#stencila-docker-images)
+Download the AppImage\* file for the latest [Stencila Desktop release]( https://github.com/stencila/desktop/releases). Then double click on it and click *yes* to "Make executable and run". Or, to install from the command line, navigate to the folder where the AppImage file is located and then:
 
 ```bash
 $ chmod a+x stencila-desktop-*.AppImage
@@ -52,7 +53,7 @@ The basic installation of Stencila Desktop  has built in support for executing c
 >! We are currently working on making Stencila's Docker images compatible with the latest Stencila Desktop. During that process, not all functionality may be available.
 
 You can also enable use of all the above programming languages in one go by using one of the [Docker](https://www.docker.com/) images that we provide.
- The Docker images bundle these language packages, plus many other packages that our useful in data-driven research, in one reproducible computing environment.
+ The Docker images bundle these language packages, plus many other packages that are useful in data-driven research, in one reproducible computing environment.
  Stencila has several Docker images available in the [`stencila/images`](https://github.com/stencila/images) repository.
 
  **Prerequisites** You need to have [Docker installed](https://docs.docker.com/install/) first before you can enable any of the images.


### PR DESCRIPTION
- Hide outdated documentation pages
- Update `converter` to `encoda`, and update docs
- Tweak marketing to remove Desktop/Sheets, emphasize code/metadata preserved throughout authoring and publication process.